### PR TITLE
changes for fully automatic vagrant startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ source storage.tcl
 
 Compile Jim Tcl 0.76 or later from the Git repository. Previous stable
 releases (0.75 or earlier) will not work. You will need an SQLite3 development
-package (`libsqlite3-dev` on Debian/Ubuntu, `libsqlite3x-devel` on Fedora).
+package (`libsqlite3-dev` on Debian/Ubuntu, `libsqlite3x-devel` on
+Fedora) and `asciidoc` to create the documentation (don't use
+`--disable-docs` then).
 
 ```sh
 git clone https://github.com/msteveb/jimtcl.git
 cd jimtcl
-./configure --with-ext="oo tree binary sqlite3" --enable-utf8 --ipv6
+./configure --with-ext="oo tree binary sqlite3" --enable-utf8 --ipv6 --disable-docs
 make
 sudo make install
 ```
@@ -68,7 +70,6 @@ Run the following commands in the terminal:
 ```sh
 git clone https://github.com/dbohdan/jimhttp.git
 cd jimhttp/vagrant
-vagrant box add ubuntu/trusty64
 vagrant up
 ```
 
@@ -77,14 +78,11 @@ the server when you edit `example.tcl`.
 
 Stop the VM with
 
-    ^C
-    ^C
     vagrant halt
 
 Run the server again with
 
     vagrant up
-    vagrant provision
 
 # License
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.provision :shell, path: "bootstrap.sh"
+  config.vm.provision :shell, path: "bootstrap.sh", run: "always"
   config.vm.synced_folder "..", "/jimhttp"
 
   config.vm.provider :virtualbox do |vb|

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -5,11 +5,4 @@ if test ! -x "$(which jimsh)"; then
     /vagrant/install-jimtcl.sh
 fi
 
-# Run jimhttp in a loop. curl localhost:8080/quit to restart.
-cd /jimhttp
-echo Starting example.tcl on port 8080.
-while true; do
-    jimsh example.tcl -i 0.0.0.0 -p 8080 -v 5
-    echo Restarting example.tcl on port 8080.
-    sleep 1
-done
+/vagrant/testserver.sh > /vagrant/testserver.log 2>&1 &

--- a/vagrant/install-jimtcl.sh
+++ b/vagrant/install-jimtcl.sh
@@ -6,7 +6,7 @@ apt-get -y install git build-essential libsqlite3-dev
 git clone https://github.com/msteveb/jimtcl.git
 cd jimtcl
 git checkout --detach 0.76
-./configure --with-ext="oo tree binary sqlite3" --enable-utf8 --ipv6
+./configure --with-ext="oo tree binary sqlite3" --enable-utf8 --ipv6 --disable-docs
 make
 make install
 cd ..

--- a/vagrant/testserver.sh
+++ b/vagrant/testserver.sh
@@ -1,0 +1,10 @@
+#/bin/sh
+
+# Run jimhttp in a loop. curl localhost:8080/quit to restart.
+cd /jimhttp
+echo Starting example.tcl on port 8080.
+while true; do
+    jimsh example.tcl -i 0.0.0.0 -p 8080 -v 5
+    echo Restarting example.tcl on port 8080.
+    sleep 1
+done


### PR DESCRIPTION
Now it's sufficient to do `vagrant up` to start the server and don't block the current shell. Also the building of docs for jimtcl in the vagrant box is inhibited because the needed package asciidoc is missing.
